### PR TITLE
Test removing depends

### DIFF
--- a/pop3.nimble
+++ b/pop3.nimble
@@ -4,6 +4,3 @@ version: "0.1"
 author: "Federico Ceratto"
 description: "POP3 client library"
 license: "LGPLv3"
-
-[Deps]
-requires: ""


### PR DESCRIPTION
Apparently nimble doesn't like an empty dep field, so I removed it altogether